### PR TITLE
ci: bump action runtime to node24

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   bump:
     if: ${{ github.event.inputs.confirm  == 'confirm' }}
-    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-major-version.yml@v1
+    if: ${{ github.event.inputs.confirm  == 'confirm' }}
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   bump:
     if: ${{ github.event.pull_request.merged }}
-    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-minor-version.yml@v1
+    if: ${{ github.event.pull_request.merged }}
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -7,11 +7,19 @@ on:
       - alpha/v*/v*
       - release/v*/v*
 
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
-    uses: kungfu-trader/workflows/.github/workflows/.release-new-version.yml@v1
+    if: ${{ github.event.pull_request.merged }}
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v2/v2.0
     with:
       publish-aws-ci: false
       publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   release:
     if: ${{ github.event.pull_request.merged }}
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2.0-alpha
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,21 +1,31 @@
 name: Release - Verify
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - alpha/*/*
       - release/*/*
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   try:
-    uses: kungfu-trader/workflows/.github/workflows/.release-verify.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v2/v2.0
     with:
       prebuild: false
+      build-container-enabled: false
+      setup-python-enabled: false
+      publish-versioning: false
+      publish-aws-ci: false
+      publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
   
   verify:
     needs: try
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: report
         run: echo verified

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2.0-alpha
     with:
       prebuild: false
       build-container-enabled: false
@@ -21,7 +21,7 @@ jobs:
       publish-versioning: false
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4.0-alpha
   
   verify:
     needs: try

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: "secrets.MONDAY_API_KEY"
     required: true
 runs:
-  using: "node16"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary
- bump the GitHub Action runtime from node16 to node24
- keep the existing bundled dist entrypoint unchanged

## Validation
- python YAML parse confirms `runs.using: node24`
- Node v24.16.0 can require `dist/index.js` successfully

## Notes
- Node 24 still reports the existing DEP0040 punycode warning from bundled dependencies during a local require check. This PR only removes the GitHub Actions runtime deprecation path; dependency cleanup should be handled separately.